### PR TITLE
#157488075 Fix permission issue for shops on heroku

### DIFF
--- a/imports/plugins/custom/reviews/client/css/reviews.css
+++ b/imports/plugins/custom/reviews/client/css/reviews.css
@@ -16,8 +16,8 @@
 }
 
 .review-button {
-  border: 1px solid #5cde86;
-  background-color: #5cde86;
+  border: 1px solid #f98d3f;
+  background-color: #f98d3f;
   flex: 1 1 auto;
   border-radius: 0 2px 2px 0;
   -webkit-box-flex: 1;
@@ -27,8 +27,8 @@
 }
 
 .review-button:visited, .review-button:active, .review-button:link {
-  border: 1px solid #5cde86;
-  background-color: #5cde86;
+  border: 1px solid #f98d3f;
+  background-color: #f98d3f;
   flex: 1 1 auto;
   border-radius: 0 2px 2px 0;
   -webkit-box-flex: 1;
@@ -38,8 +38,8 @@
 }
 
 .review-button:hover {
-  border: 1px solid #248232;
-  background-color: #248232;
+  border: 1px solid #f98c3e;
+  background-color: #f98c3e;
   flex: 1 1 auto;
   border-radius: 0 2px 2px 0;
   -webkit-box-flex: 1;

--- a/imports/plugins/custom/shop-reviews/client/containers/reviews.jsx
+++ b/imports/plugins/custom/shop-reviews/client/containers/reviews.jsx
@@ -76,7 +76,10 @@ class ShopReviewsContainer extends Component {
   render() {
     return (
       <div className="row">
-        <div className="col-lg-9 col-md-9 col-sm-12 col-md-12"><Components.Products products={this.props.products}/></div>
+        <div className="col-lg-9 col-md-9 col-sm-12 col-md-12">
+          <div className="shop-name">{this.state.shop.name}</div>
+          <Components.Products products={this.props.products}/>
+        </div>
         <div className="col-lg-3 col-md-3 col-sm-12 col-md-12">
           <div className="shop-reviews-heading">
             All reviews <br />

--- a/imports/plugins/custom/shop-reviews/client/css/shop-reviews.css
+++ b/imports/plugins/custom/shop-reviews/client/css/shop-reviews.css
@@ -37,3 +37,10 @@
   text-decoration: underline;
   font-size: 20px;
 }
+
+.shop-name {
+  font-size: 30px;
+  text-align: center;
+  padding: 10px 0px;
+  text-decoration: underline;
+}

--- a/imports/plugins/custom/shop-reviews/server/index.js
+++ b/imports/plugins/custom/shop-reviews/server/index.js
@@ -1,2 +1,3 @@
 import "./methods";
 import "./publications/reviews";
+import "./init";

--- a/imports/plugins/custom/shop-reviews/server/init.js
+++ b/imports/plugins/custom/shop-reviews/server/init.js
@@ -1,0 +1,7 @@
+import { Hooks } from "/server/api";
+import { addRolesToGroups } from "/server/api/core/addDefaultRoles";
+
+
+Hooks.Events.add("afterCoreInit", () => {
+  addRolesToGroups({ allShops: true, roles: ["shops"], shops: [], groups: ["guest", "anonymous", "customer"] });
+});


### PR DESCRIPTION
#### What does this PR do?
fix permission issue for shops on heroku
#### Description of Task to be completed?
* add the shops role to the existing groups after initialization
* add shop name to the shop page
* change color for review button
#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run `meteor npm install` to install project dependecies
* install `ImageMagick`
* run `reaction` to start up the app
* click on `Sign In` at the top right corner and register
* click on `Guest` at the top right corner
* click on `Profile` and edit your details and save
* click on `Reaction` at the top left corner
* click on any product on the page
* you should see a review under the modal
* click on the Reaction link under the product title
* click on the Add Review modal at the right side of the new page
* click on a star to rate and also give a review
* click `Add Review` to save
* you should see a review under the modal
#### Any background context you want to provide?
users can't access shop's page if they aren't admins
#### What are the relevant pivotal tracker stories?(if applicable)
#157488075