### PR TITLE
#157032081 Add cancel order option

### DIFF
--- a/imports/plugins/core/accounts/client/components/ordersList.js
+++ b/imports/plugins/core/accounts/client/components/ordersList.js
@@ -12,12 +12,13 @@ import CompletedOrder from "../../../checkout/client/components/completedOrder";
 class OrdersList extends Component {
   static propTypes = {
     allOrdersInfo: PropTypes.array,
+    cancelOrder: PropTypes.func,
     handleDisplayMedia: PropTypes.func,
     isProfilePage: PropTypes.bool
   }
 
   render() {
-    const { allOrdersInfo, handleDisplayMedia } = this.props;
+    const { allOrdersInfo, handleDisplayMedia, cancelOrder } = this.props;
 
     if (allOrdersInfo) {
       return (
@@ -35,6 +36,7 @@ class OrdersList extends Component {
                 productImages={order.productImages}
                 handleDisplayMedia={handleDisplayMedia}
                 isProfilePage={this.props.isProfilePage}
+                cancelOrder={cancelOrder}
               />
             );
           })}

--- a/imports/plugins/core/checkout/client/components/completedOrder.js
+++ b/imports/plugins/core/checkout/client/components/completedOrder.js
@@ -18,7 +18,7 @@ import AddEmail from "./addEmail";
  * @property {Booleam} isProfilePage - A boolean value that checks if current page is user profile page
  * @return {Node} React node containing the top-level component for displaying the completed order/receipt page
  */
-const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, handleDisplayMedia, isProfilePage }) => {
+const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, handleDisplayMedia, isProfilePage, cancelOrder }) => {
   if (!order) {
     return (
       <Components.NotFound
@@ -102,6 +102,13 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
         </div>
         <CompletedOrderSummary shops={shops} orderSummary={orderSummary} isProfilePage={isProfilePage} />
         {/* This is the right side / side content */}
+
+        {
+          isProfilePage && order.workflow.status === "coreOrderWorkflow/canceled" ?
+            <button className="rui btn btn-info" type="button" id="order-canceled-btn" disabled>This order is canceled</button> :
+            <button className="rui btn" type="button" id="cancel-order-btn" onClick={() => cancelOrder(order)}>Cancel Order</button>
+        }
+
       </div>
 
     </div>
@@ -109,6 +116,7 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
 };
 
 CompletedOrder.propTypes = {
+  cancelOrder: PropTypes.func,
   handleDisplayMedia: PropTypes.func,
   isProfilePage: PropTypes.bool,
   order: PropTypes.object,

--- a/imports/plugins/custom/casablanca-theme/client/styles/styles.less
+++ b/imports/plugins/custom/casablanca-theme/client/styles/styles.less
@@ -134,9 +134,13 @@
     background-color: @casablanca-orange;
     border: lighten(@casablanca-orange, 25%);
     outline: none;
+    max-width: 50%;
   }
   button:hover {
     background-color: darken(@casablanca-orange, 5%);
+  }
+  &.block {
+    justify-content: center;
   }
 }
 
@@ -191,3 +195,25 @@
 }
 
 /* All about Wallet */
+
+
+/* Orders list */
+
+.user-orders-list {
+  .order-completed {
+    padding-bottom: 25px;
+  }
+  #cancel-order-btn {
+    margin-top: 15px;
+    background-color: white;
+    color: black;
+    border: 1px solid grey;
+    &:hover, &:active, &:focus {
+      background-color: #e6e6e6;
+    }
+  }
+  #order-canceled-btn {
+    margin-top: 15px;
+  }
+}
+/* Orders list */

--- a/server/methods/accounts/accounts.js
+++ b/server/methods/accounts/accounts.js
@@ -1049,11 +1049,11 @@ export const getWalletBalance = () => {
  * @summary Adds more fund to the wallet.
  * @returns {Boolean} - returns boolean.
  */
-export const addToWallet = (amount) => {
+export const addToWallet = (amount, userId) => {
   check(amount, validAmountCheck);
   const user = Meteor.user();
   Accounts.update({
-    _id: user._id
+    _id: userId || user._id
   }, {
     $inc: {
       walletBalance: amount


### PR DESCRIPTION
#### What does this PR do?
Add cancel order option for the user that created an order.
#### Description of Task to be completed?
Users should be able to cancel an order
#### How should this be manually tested?
- clone the repo and change into the project directory
- start the application(instructions in the readme)
- visit the application in the browser 
- login/signup as a user
- buy some products
- visit your profile
- you would see a list of all your orders and an option to cancel any one of them
- try canceling one of the orders
- a pop-up box would appear, the pop-up would tell you the status of the order(new, processing, or shipped) and how much you are going to be refunded with after canceling.
- if you continue with the cancelation, your Wallet would be refunded and the wallet balance would increase by the refund
#### What are the relevant pivotal tracker stories?
#157032081
#### Background Context
Since the payments option that we have are not using actual money for the transactions, all refund would go into the wallet(in considering the payment method used to purchase the product).
#### Screenshots
<img width="990" alt="screen shot 2018-05-17 at 11 10 37 pm" src="https://user-images.githubusercontent.com/26048536/40206391-ca72323e-5a27-11e8-9922-03790abcd56a.png">
<img width="1012" alt="screen shot 2018-05-17 at 11 11 47 pm" src="https://user-images.githubusercontent.com/26048536/40206398-d79f6f3a-5a27-11e8-9b40-4a3b16352794.png">
<img width="1113" alt="screen shot 2018-05-17 at 11 11 22 pm" src="https://user-images.githubusercontent.com/26048536/40206404-e241949a-5a27-11e8-8301-7d430bc75e39.png">
<img width="990" alt="screen shot 2018-05-17 at 11 14 19 pm" src="https://user-images.githubusercontent.com/26048536/40206464-16b27578-5a28-11e8-9d43-ecf7a79ea21b.png">







