### PR TITLE
#157626915 Add popup confirmation before any Wallet transaction

### DIFF
--- a/imports/plugins/core/accounts/client/templates/wallet/wallet.js
+++ b/imports/plugins/core/accounts/client/templates/wallet/wallet.js
@@ -82,15 +82,24 @@ const addToFriendWallet = (amount, email) => {
   const template = Template.instance();
   const amountInput = template.$("#transfer-amount");
   const recipientEmail = template.$("#transfer-email");
-  Meteor.call("accounts/addToFriendWallet", amount, email, function (err, data) {
-    if (!err) {
-      if (!data) {
-        Alerts.toast("Email is invalid. Please try again", "error");
-      } else {
-        Alerts.toast(`Successful transfer of ${amount} to ${email}`);
-        amountInput.val("");
-        recipientEmail.val("");
-      }
+  Alerts.alert({
+    title: `Transfer ₦${amount} from your account?`,
+    type: "warning",
+    showCancelButton: true,
+    confirmButtonText: "Continue"
+  }, (isConfirm) => {
+    if (isConfirm) {
+      Meteor.call("accounts/addToFriendWallet", amount, email, function (err, data) {
+        if (!err) {
+          if (!data) {
+            Alerts.toast("Email is invalid. Please try again", "error");
+          } else {
+            Alerts.toast(`Successful transfer of ${amount} to ${email}`);
+            amountInput.val("");
+            recipientEmail.val("");
+          }
+        }
+      });
     }
   });
 };

--- a/imports/plugins/core/payments/client/checkout/payment/payment.html
+++ b/imports/plugins/core/payments/client/checkout/payment/payment.html
@@ -9,6 +9,7 @@
     </div>
 
     <div class="core-payment-methods panel-body">
+      <p style="text-align: center; margin: 0px; font-size: 13px;">Choose a payment option</p>
       {{> corePaymentMethods}}
       <div id="payment-alerts">{{> inlineAlerts placement="paymentMethod"}}</div>
     </div>

--- a/imports/plugins/custom/payments-paystack/client/checkout/paystack.html
+++ b/imports/plugins/custom/payments-paystack/client/checkout/paystack.html
@@ -1,29 +1,35 @@
 <template name="paystackPaymentForm">
-  {{#autoForm schema=PaystackPayment id="paystack-payment-form"}}
-  <div class="row">
-    <div class="form-group{{#if afFieldIsInvalid name='name'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='name'}}</label>
-        {{>afFieldInput name="name" value=cartPayerName}}
-        {{#if afFieldIsInvalid name="name"}}
-        <span class="help-block">{{afFieldMessage name="name"}}</span>
-        {{/if}}
+  <button id="toggleForm" class="rui btn btn-lg btn-block btn-primary">Paystack</button>
+  {{#if formVisibility}}
+
+    {{#autoForm schema=PaystackPayment id="paystack-payment-form"}}
+    <div class="row">
+      <div class="form-group{{#if afFieldIsInvalid name='name'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='name'}}</label>
+          {{>afFieldInput name="name" value=cartPayerName}}
+          {{#if afFieldIsInvalid name="name"}}
+          <span class="help-block">{{afFieldMessage name="name"}}</span>
+          {{/if}}
+      </div>
+
+      <div class="form-group{{#if afFieldIsInvalid name='email'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='email'}}</label>
+          {{>afFieldInput name="email" placeholder='email'}}
+          {{#if afFieldIsInvalid name="email"}}
+          <span class="help-block">{{afFieldMessage name="email"}}</span>
+          {{/if}}
+      </div>
     </div>
 
-    <div class="form-group{{#if afFieldIsInvalid name='email'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='email'}}</label>
-        {{>afFieldInput name="email" placeholder='email'}}
-        {{#if afFieldIsInvalid name="email"}}
-        <span class="help-block">{{afFieldMessage name="email"}}</span>
-        {{/if}}
-    </div>
-  </div>
 
+    <div class="alert alert-danger hidden">Oh! Snap!</div>
+    <button type="submit" class="rui btn btn-lg btn-cta btn-block btn-complete-order">
+      <span id="btn-complete-order" data-i18n="checkoutPayment.completeYourOrder">Complete your order</span>
+      <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
+    </button>
 
-  <div class="alert alert-danger hidden">Oh! Snap!</div>
-  <button type="submit" class="rui btn btn-lg btn-cta btn-block btn-complete-order">
-    <span id="btn-complete-order" data-i18n="checkoutPayment.completeYourOrder">Complete your order</span>
-    <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
-  </button>
+    {{/autoForm}}
 
-  {{/autoForm}}
+  {{/if}}
+
 </template>

--- a/imports/plugins/custom/payments-paystack/client/checkout/paystack.js
+++ b/imports/plugins/custom/payments-paystack/client/checkout/paystack.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
 import { AutoForm } from "meteor/aldeed:autoform";
 import { $ } from "meteor/jquery";
 import { Reaction } from "/client/api";
@@ -37,9 +38,23 @@ function handlePaystackSubmitError(error) {
 }
 
 
+Template.paystackPaymentForm.onCreated(function () {
+  this.formVisibility = new ReactiveVar(false);
+});
+
 Template.paystackPaymentForm.helpers({
   PaystackPayment() {
     return PaystackPayment;
+  },
+
+  formVisibility() {
+    return Template.instance().formVisibility.get();
+  }
+});
+
+Template.paystackPaymentForm.events({
+  "click #toggleForm": (event, template) => {
+    template.formVisibility.set(!template.formVisibility.get());
   }
 });
 

--- a/imports/plugins/custom/wallet-payment/client/checkout/wallet.html
+++ b/imports/plugins/custom/wallet-payment/client/checkout/wallet.html
@@ -1,11 +1,15 @@
 <template name="walletPaymentForm">
+  <button id="toggleForm" class="rui btn btn-lg btn-block btn-primary">Wallet</button>
+  {{#if formVisibility}}
 
-  <div class="wallet-payment-details">
-    <h3>Pay With Wallet</h3>
-    <span><b>₦{{totalPrice}}</b> would be deducted from your wallet.</span>
-  </div>
-  <button class="rui btn btn-lg btn-cta btn-block btn-complete-order" id="submitWalletPayment">
-    <span id="btn-complete-order" data-i18n="checkoutPayment.completeYourOrder">Complete your order</span>
-  </button>
+    <div class="wallet-payment-details">
+      <h3>Pay With Wallet</h3>
+      <span><b>₦{{totalPrice}}</b> would be deducted from your wallet.</span>
+    </div>
+    <button class="rui btn btn-lg btn-cta btn-block btn-complete-order" id="submitWalletPayment">
+      <span id="btn-complete-order" data-i18n="checkoutPayment.completeYourOrder">Complete your order</span>
+    </button>
+
+  {{/if}}
 
 </template>

--- a/imports/plugins/custom/wallet-payment/client/checkout/wallet.js
+++ b/imports/plugins/custom/wallet-payment/client/checkout/wallet.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 import { Meteor } from "meteor/meteor";
 import { Random } from "meteor/random";
+import { ReactiveVar } from "meteor/reactive-var";
 import { Template } from "meteor/templating";
 import { Reaction } from "/client/api";
 import { Cart, Shops, Packages } from "/lib/collections";
@@ -16,9 +17,17 @@ const deductFromWallet = (amount) => {
   Meteor.call("accounts/deductFromWallet", amount);
 };
 
+Template.walletPaymentForm.onCreated(function () {
+  this.formVisibility = new ReactiveVar(false);
+});
+
 Template.walletPaymentForm.helpers({
   totalPrice() {
     return Cart.findOne().getTotal();
+  },
+
+  formVisibility() {
+    return Template.instance().formVisibility.get();
   }
 });
 
@@ -70,5 +79,9 @@ Template.walletPaymentForm.events({
         });
       }
     });
+  },
+
+  "click #toggleForm": (event, template) => {
+    template.formVisibility.set(!template.formVisibility.get());
   }
 });

--- a/imports/plugins/custom/wallet-payment/client/checkout/wallet.js
+++ b/imports/plugins/custom/wallet-payment/client/checkout/wallet.js
@@ -34,27 +34,38 @@ Template.walletPaymentForm.events({
     });
     Meteor.call("accounts/getWalletBalance", (error, result) => {
       if (amount > result) {
+        // Display an error alert
         Alerts.alert("You do not have enough money to purchase this product.");
       } else {
-        // Make the payment
-        const paymentMethod = {
-          processor: "Wallet",
-          method: "credit",  // ?
-          paymentPackageId: packageData._id,
-          paymentSettingsKey: packageData.registry[0].settingsKey,
-          transactionId: Random.id(),
-          currency,
-          amount,
-          status: "passed", // ?
-          mode: "authorize",
-          createdAt: new Date(),
-          transactions: []
-        };
-        Meteor.call("cart/submitPayment", paymentMethod, (submitPaymentError) => {
-          if (submitPaymentError) {
-            Alerts.toast(submitPaymentError.message, "error");
-          } else {
-            deductFromWallet(amount);
+        // Display a warning alert
+        Alerts.alert({
+          title: "Completing this order would deduct from your wallet.",
+          type: "warning",
+          showCancelButton: true,
+          confirmButtonText: "Continue"
+        }, (isConfirm) => {
+          // Make the payment
+          if (isConfirm) {
+            const paymentMethod = {
+              processor: "Wallet",
+              method: "credit",
+              paymentPackageId: packageData._id,
+              paymentSettingsKey: packageData.registry[0].settingsKey,
+              transactionId: Random.id(),
+              currency,
+              amount,
+              status: "passed",
+              mode: "authorize",
+              createdAt: new Date(),
+              transactions: []
+            };
+            Meteor.call("cart/submitPayment", paymentMethod, (submitPaymentError) => {
+              if (submitPaymentError) {
+                Alerts.toast(submitPaymentError.message, "error");
+              } else {
+                deductFromWallet(amount);
+              }
+            });
           }
         });
       }

--- a/imports/plugins/included/payments-authnet/client/checkout/authnet.html
+++ b/imports/plugins/included/payments-authnet/client/checkout/authnet.html
@@ -1,53 +1,56 @@
 <template name="authnetPaymentForm">
-  {{#autoForm schema=AuthNetPayment id="authnet-payment-form"}}
-  <div class="row">
-    <div class="form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
-        {{>afFieldInput name="payerName" value=cartPayerName}}
-        {{#if afFieldIsInvalid name="payerName"}}
-        <span class="help-block">{{afFieldMessage name="payerName"}}</span>
-        {{/if}}
+  <button id="toggleForm" class="rui btn btn-lg btn-block btn-primary">Authnet</button>
+  {{#if formVisibility}}
+    {{#autoForm schema=AuthNetPayment id="authnet-payment-form"}}
+    <div class="row">
+        <div class="form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
+            <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
+            {{>afFieldInput name="payerName" value=cartPayerName}}
+            {{#if afFieldIsInvalid name="payerName"}}
+            <span class="help-block">{{afFieldMessage name="payerName"}}</span>
+            {{/if}}
+        </div>
+
+        <div class="form-group{{#if afFieldIsInvalid name='cardNumber'}} has-error{{/if}}">
+            <label class="control-label">{{afFieldLabelText name='cardNumber'}}</label>
+            {{>afFieldInput name="cardNumber" placeholder='XXXX XXXX XXXX XXXX'}}
+            {{#if afFieldIsInvalid name="cardNumber"}}
+            <span class="help-block">{{afFieldMessage name="cardNumber"}}</span>
+            {{/if}}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
+            <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
+            {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
+            {{#if afFieldIsInvalid name="expireMonth"}}
+            <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
+            {{/if}}
+        </div>
+
+        <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
+            <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
+            {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
+            {{#if afFieldIsInvalid name="expireYear"}}
+            <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
+            {{/if}}
+        </div>
+
+        <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
+            <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
+            {{>afFieldInput name="cvv" placeholder="CVV"}}
+            {{#if afFieldIsInvalid name="cvv"}}
+            <span class="help-block">{{afFieldMessage name="cvv"}}</span>
+            {{/if}}
+        </div>
     </div>
 
-    <div class="form-group{{#if afFieldIsInvalid name='cardNumber'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='cardNumber'}}</label>
-        {{>afFieldInput name="cardNumber" placeholder='XXXX XXXX XXXX XXXX'}}
-        {{#if afFieldIsInvalid name="cardNumber"}}
-        <span class="help-block">{{afFieldMessage name="cardNumber"}}</span>
-        {{/if}}
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
-        {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
-        {{#if afFieldIsInvalid name="expireMonth"}}
-        <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
-        {{/if}}
-    </div>
+    <div class="alert alert-danger hidden">Oh! Snap!</div>
+    <button type="submit" class="rui btn btn-lg btn-cta btn-block">
+        <span id="btn-complete-order">Complete your order</span>
+        <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
+    </button>
 
-    <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
-        {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
-        {{#if afFieldIsInvalid name="expireYear"}}
-        <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
-        {{/if}}
-    </div>
-
-    <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
-        {{>afFieldInput name="cvv" placeholder="CVV"}}
-        {{#if afFieldIsInvalid name="cvv"}}
-        <span class="help-block">{{afFieldMessage name="cvv"}}</span>
-        {{/if}}
-    </div>
-  </div>
-
-  <div class="alert alert-danger hidden">Oh! Snap!</div>
-  <button type="submit" class="rui btn btn-lg btn-cta btn-block">
-    <span id="btn-complete-order">Complete your order</span>
-    <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
-  </button>
-
-  {{/autoForm}}
+    {{/autoForm}}
+  {{/if}}
 </template>

--- a/imports/plugins/included/payments-authnet/client/checkout/authnet.js
+++ b/imports/plugins/included/payments-authnet/client/checkout/authnet.js
@@ -1,5 +1,6 @@
 /* eslint camelcase: 0 */
 import { Meteor } from "meteor/meteor";
+import { ReactiveVar } from "meteor/reactive-var";
 import { $ } from "meteor/jquery";
 import { Template } from "meteor/templating";
 import { Reaction, Logger } from "/client/api";
@@ -35,9 +36,23 @@ function handleAuthNetSubmitError(error) {
 // used to track asynchronous submitting for UI changes
 let submitting = false;
 
+Template.authnetPaymentForm.onCreated(function () {
+  this.formVisibility = new ReactiveVar(false);
+});
+
 Template.authnetPaymentForm.helpers({
   AuthNetPayment() {
     return AuthNetPayment;
+  },
+
+  formVisibility() {
+    return Template.instance().formVisibility.get();
+  }
+});
+
+Template.authnetPaymentForm.events({
+  "click #toggleForm": (event, template) => {
+    template.formVisibility.set(!template.formVisibility.get());
   }
 });
 

--- a/imports/plugins/included/payments-braintree/client/checkout/braintree.html
+++ b/imports/plugins/included/payments-braintree/client/checkout/braintree.html
@@ -1,53 +1,56 @@
 <template name="braintreePaymentForm">
-  {{#autoForm schema=BraintreePayment id="braintree-payment-form"}}
-  <div class="row">
-    <div class="form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
-      <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
-      {{>afFieldInput name="payerName" value=cartPayerName}}
-      {{#if afFieldIsInvalid name="payerName"}}
-      <span class="help-block">{{afFieldMessage name="payerName"}}</span>
-      {{/if}}
+  <button id="toggleForm" class="rui btn btn-lg btn-block btn-primary">Braintree</button>
+  {{#if formVisibility}}
+    {{#autoForm schema=BraintreePayment id="braintree-payment-form"}}
+    <div class="row">
+      <div class="form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
+        <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
+        {{>afFieldInput name="payerName" value=cartPayerName}}
+        {{#if afFieldIsInvalid name="payerName"}}
+        <span class="help-block">{{afFieldMessage name="payerName"}}</span>
+        {{/if}}
+      </div>
+
+      <div class="form-group{{#if afFieldIsInvalid name='cardNumber'}} has-error{{/if}}">
+        <label class="control-label">{{afFieldLabelText name='cardNumber'}}</label>
+        {{>afFieldInput name="cardNumber" placeholder='XXXX XXXX XXXX XXXX'}}
+        {{#if afFieldIsInvalid name="cardNumber"}}
+        <span class="help-block">{{afFieldMessage name="cardNumber"}}</span>
+        {{/if}}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
+        <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
+        {{>afFieldInput name="expireMonth" options=monthOptions placeholder="Exp. Month"}}
+        {{#if afFieldIsInvalid name="expireMonth"}}
+        <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
+        {{/if}}
+      </div>
+
+      <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
+        <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
+        {{>afFieldInput name="expireYear" options=yearOptions placeholder="Exp. Year"}}
+        {{#if afFieldIsInvalid name="expireYear"}}
+        <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
+        {{/if}}
+      </div>
+
+      <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
+        <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
+        {{>afFieldInput name="cvv" placeholder="CVV"}}
+        {{#if afFieldIsInvalid name="cvv"}}
+        <span class="help-block">{{afFieldMessage name="cvv"}}</span>
+        {{/if}}
+      </div>
     </div>
 
-    <div class="form-group{{#if afFieldIsInvalid name='cardNumber'}} has-error{{/if}}">
-      <label class="control-label">{{afFieldLabelText name='cardNumber'}}</label>
-      {{>afFieldInput name="cardNumber" placeholder='XXXX XXXX XXXX XXXX'}}
-      {{#if afFieldIsInvalid name="cardNumber"}}
-      <span class="help-block">{{afFieldMessage name="cardNumber"}}</span>
-      {{/if}}
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
-      <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
-      {{>afFieldInput name="expireMonth" options=monthOptions placeholder="Exp. Month"}}
-      {{#if afFieldIsInvalid name="expireMonth"}}
-      <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
-      {{/if}}
-    </div>
+    <div class="alert alert-danger hidden">Oh! Snap!</div>
+    <button type="submit" class="rui btn btn-lg btn-cta btn-block">
+      <span id="btn-complete-order">Complete your order</span>
+      <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
+    </button>
 
-    <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
-      <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
-      {{>afFieldInput name="expireYear" options=yearOptions placeholder="Exp. Year"}}
-      {{#if afFieldIsInvalid name="expireYear"}}
-      <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
-      {{/if}}
-    </div>
-
-    <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
-      <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
-      {{>afFieldInput name="cvv" placeholder="CVV"}}
-      {{#if afFieldIsInvalid name="cvv"}}
-      <span class="help-block">{{afFieldMessage name="cvv"}}</span>
-      {{/if}}
-    </div>
-  </div>
-
-  <div class="alert alert-danger hidden">Oh! Snap!</div>
-  <button type="submit" class="rui btn btn-lg btn-cta btn-block">
-    <span id="btn-complete-order">Complete your order</span>
-    <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
-  </button>
-
-  {{/autoForm}}
+    {{/autoForm}}
+  {{/if}}
 </template>

--- a/imports/plugins/included/payments-braintree/client/checkout/braintree.js
+++ b/imports/plugins/included/payments-braintree/client/checkout/braintree.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
 import { AutoForm } from "meteor/aldeed:autoform";
 import { $ } from "meteor/jquery";
 import { getCardType } from "/client/modules/core/helpers/globals";
@@ -11,9 +12,23 @@ import { BraintreePayment } from "../../lib/collections/schemas";
 
 import "./braintree.html";
 
+Template.braintreePaymentForm.onCreated(function () {
+  this.formVisibility = new ReactiveVar(false);
+});
+
 Template.braintreePaymentForm.helpers({
   BraintreePayment() {
     return BraintreePayment;
+  },
+
+  formVisibility() {
+    return Template.instance().formVisibility.get();
+  }
+});
+
+Template.braintreePaymentForm.events({
+  "click #toggleForm": (event, template) => {
+    template.formVisibility.set(!template.formVisibility.get());
   }
 });
 

--- a/imports/plugins/included/payments-example/client/checkout/example.html
+++ b/imports/plugins/included/payments-example/client/checkout/example.html
@@ -1,55 +1,58 @@
 <template name="examplePaymentForm">
-  {{#autoForm schema=ExamplePayment id="example-payment-form"}}
-  <div class="row">
-    <div class="form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
-        {{>afFieldInput name="payerName" value=cartPayerName}}
-        {{#if afFieldIsInvalid name="payerName"}}
-        <span class="help-block">{{afFieldMessage name="payerName"}}</span>
-        {{/if}}
+  <button id="toggleForm" class="rui btn btn-lg btn-block btn-primary">Example Payment</button>
+  {{#if formVisibility}}
+    {{#autoForm schema=ExamplePayment id="example-payment-form"}}
+    <div class="row">
+      <div class="form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
+          {{>afFieldInput name="payerName" value=cartPayerName}}
+          {{#if afFieldIsInvalid name="payerName"}}
+          <span class="help-block">{{afFieldMessage name="payerName"}}</span>
+          {{/if}}
+      </div>
+
+      <div class="form-group{{#if afFieldIsInvalid name='cardNumber'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='cardNumber'}}</label>
+          {{>afFieldInput name="cardNumber" placeholder='XXXX XXXX XXXX XXXX'}}
+          {{#if afFieldIsInvalid name="cardNumber"}}
+          <span class="help-block">{{afFieldMessage name="cardNumber"}}</span>
+          {{/if}}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
+          {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
+          {{#if afFieldIsInvalid name="expireMonth"}}
+          <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
+          {{/if}}
+      </div>
+
+      <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
+          {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
+          {{#if afFieldIsInvalid name="expireYear"}}
+          <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
+          {{/if}}
+      </div>
+
+    </div>
+    <div class="row">
+      <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
+          {{>afFieldInput name="cvv" placeholder="CVV"}}
+          {{#if afFieldIsInvalid name="cvv"}}
+          <span class="help-block">{{afFieldMessage name="cvv"}}</span>
+          {{/if}}
+      </div>
     </div>
 
-    <div class="form-group{{#if afFieldIsInvalid name='cardNumber'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='cardNumber'}}</label>
-        {{>afFieldInput name="cardNumber" placeholder='XXXX XXXX XXXX XXXX'}}
-        {{#if afFieldIsInvalid name="cardNumber"}}
-        <span class="help-block">{{afFieldMessage name="cardNumber"}}</span>
-        {{/if}}
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
-        {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
-        {{#if afFieldIsInvalid name="expireMonth"}}
-        <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
-        {{/if}}
-    </div>
+    <div class="alert alert-danger hidden">Oh! Snap!</div>
+    <button type="submit" class="rui btn btn-lg btn-cta btn-block btn-complete-order">
+      <span id="btn-complete-order" data-i18n="checkoutPayment.completeYourOrder">Complete your order</span>
+      <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
+    </button>
 
-    <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
-        {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
-        {{#if afFieldIsInvalid name="expireYear"}}
-        <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
-        {{/if}}
-    </div>
-
-  </div>
-  <div class="row">
-    <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
-        {{>afFieldInput name="cvv" placeholder="CVV"}}
-        {{#if afFieldIsInvalid name="cvv"}}
-        <span class="help-block">{{afFieldMessage name="cvv"}}</span>
-        {{/if}}
-    </div>
-  </div>
-
-  <div class="alert alert-danger hidden">Oh! Snap!</div>
-  <button type="submit" class="rui btn btn-lg btn-cta btn-block btn-complete-order">
-    <span id="btn-complete-order" data-i18n="checkoutPayment.completeYourOrder">Complete your order</span>
-    <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
-  </button>
-
-  {{/autoForm}}
+    {{/autoForm}}
+  {{/if}}
 </template>

--- a/imports/plugins/included/payments-example/client/checkout/example.js
+++ b/imports/plugins/included/payments-example/client/checkout/example.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
 import { AutoForm } from "meteor/aldeed:autoform";
 import { $ } from "meteor/jquery";
 import { Reaction } from "/client/api";
@@ -36,9 +37,24 @@ function handleExampleSubmitError(error) {
 }
 
 
+Template.examplePaymentForm.onCreated(function () {
+  this.formVisibility = new ReactiveVar(false);
+});
+
 Template.examplePaymentForm.helpers({
   ExamplePayment() {
     return ExamplePayment;
+  },
+
+  formVisibility() {
+    return Template.instance().formVisibility.get();
+  }
+});
+
+
+Template.examplePaymentForm.events({
+  "click #toggleForm": (event, template) => {
+    template.formVisibility.set(!template.formVisibility.get());
   }
 });
 

--- a/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.html
+++ b/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.html
@@ -1,56 +1,57 @@
 <template name="paypalPayflowForm">
+    <button id="toggleForm" class="rui btn btn-lg btn-block btn-primary">Paypal PayFlow</button>
+    {{#if formVisibility}}
+      {{#autoForm schema=PaypalPayment id="paypal-payment-form"}}
+      <div class="row">
+        <div class="form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
+          {{>afFieldInput name="payerName" value=cartPayerName}}
+          {{#if afFieldIsInvalid name="payerName"}}
+          <span class="help-block">{{afFieldMessage name="payerName"}}</span>
+          {{/if}}
+        </div>
 
-    {{#autoForm schema=PaypalPayment id="paypal-payment-form"}}
-    <div class="row">
-      <div class="form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
-        {{>afFieldInput name="payerName" value=cartPayerName}}
-        {{#if afFieldIsInvalid name="payerName"}}
-        <span class="help-block">{{afFieldMessage name="payerName"}}</span>
-        {{/if}}
+        <div class="form-group{{#if afFieldIsInvalid name='cardNumber'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='cardNumber'}}</label>
+          {{>afFieldInput name="cardNumber" placeholder='XXXX XXXX XXXX XXXX'}}
+          {{#if afFieldIsInvalid name="cardNumber"}}
+          <span class="help-block">{{afFieldMessage name="cardNumber"}}</span>
+          {{/if}}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
+          {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
+          {{#if afFieldIsInvalid name="expireMonth"}}
+          <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
+          {{/if}}
+        </div>
+
+        <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
+          {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
+          {{#if afFieldIsInvalid name="expireYear"}}
+          <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
+          {{/if}}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
+          {{>afFieldInput name="cvv" placeholder="CVV"}}
+          {{#if afFieldIsInvalid name="cvv"}}
+          <span class="help-block">{{afFieldMessage name="cvv"}}</span>
+          {{/if}}
+        </div>
       </div>
 
-      <div class="form-group{{#if afFieldIsInvalid name='cardNumber'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='cardNumber'}}</label>
-        {{>afFieldInput name="cardNumber" placeholder='XXXX XXXX XXXX XXXX'}}
-        {{#if afFieldIsInvalid name="cardNumber"}}
-        <span class="help-block">{{afFieldMessage name="cardNumber"}}</span>
-        {{/if}}
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
-        {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
-        {{#if afFieldIsInvalid name="expireMonth"}}
-        <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
-        {{/if}}
-      </div>
+      <div class="alert alert-danger hidden">Oh! Snap!</div>
+      <button type="submit" class="rui btn btn-lg btn-cta btn-block btn-complete-order">
+        <span id="btn-complete-order" data-i18n="checkoutPayment.completeYourOrder">Complete your order</span>
+        <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
+      </button>
 
-      <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
-        {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
-        {{#if afFieldIsInvalid name="expireYear"}}
-        <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
-        {{/if}}
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
-        {{>afFieldInput name="cvv" placeholder="CVV"}}
-        {{#if afFieldIsInvalid name="cvv"}}
-        <span class="help-block">{{afFieldMessage name="cvv"}}</span>
-        {{/if}}
-      </div>
-    </div>
-
-    <div class="alert alert-danger hidden">Oh! Snap!</div>
-    <button type="submit" class="rui btn btn-lg btn-cta btn-block btn-complete-order">
-      <span id="btn-complete-order" data-i18n="checkoutPayment.completeYourOrder">Complete your order</span>
-      <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
-    </button>
-
-    {{/autoForm}}
-
+      {{/autoForm}}
+  {{/if}}
 </template>

--- a/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.js
+++ b/imports/plugins/included/payments-paypal/client/templates/checkout/payflow/payflowForm.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
 import { $ } from "meteor/jquery";
 import { AutoForm } from "meteor/aldeed:autoform";
 import Logger from "/client/modules/logger";
@@ -57,12 +58,27 @@ function handlePaypalSubmitError(error) {
   return paymentAlert(i18next.t("checkout.paymentMethod.unknownError"));
 }
 
+Template.paypalPayflowForm.onCreated(function () {
+  this.formVisibility = new ReactiveVar(false);
+});
+
 //
 // paypal payflow form helpers
 //
 Template.paypalPayflowForm.helpers({
   PaypalPayment: function () {
     return PaypalPayment;
+  },
+
+  formVisibility() {
+    return Template.instance().formVisibility.get();
+  }
+});
+
+
+Template.paypalPayflowForm.events({
+  "click #toggleForm": (event, template) => {
+    template.formVisibility.set(!template.formVisibility.get());
   }
 });
 

--- a/imports/plugins/included/payments-stripe/client/checkout/stripe.html
+++ b/imports/plugins/included/payments-stripe/client/checkout/stripe.html
@@ -1,55 +1,58 @@
 <template name="stripePaymentForm">
-  {{#autoForm schema=StripePayment id="stripe-payment-form"}}
-  <div class="row">
-    <div class="form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
-        {{>afFieldInput name="payerName" value=cartPayerName}}
-        {{#if afFieldIsInvalid name="payerName"}}
-        <span class="help-block">{{afFieldMessage name="payerName"}}</span>
-        {{/if}}
+  <button id="toggleForm" class="rui btn btn-lg btn-block btn-primary">Stripe</button>
+  {{#if formVisibility}}
+    {{#autoForm schema=StripePayment id="stripe-payment-form"}}
+    <div class="row">
+      <div class="form-group{{#if afFieldIsInvalid name='payerName'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='payerName'}}</label>
+          {{>afFieldInput name="payerName" value=cartPayerName}}
+          {{#if afFieldIsInvalid name="payerName"}}
+          <span class="help-block">{{afFieldMessage name="payerName"}}</span>
+          {{/if}}
+      </div>
+
+      <div class="form-group{{#if afFieldIsInvalid name='cardNumber'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='cardNumber'}}</label>
+          {{>afFieldInput name="cardNumber" placeholder='XXXX XXXX XXXX XXXX'}}
+          {{#if afFieldIsInvalid name="cardNumber"}}
+          <span class="help-block">{{afFieldMessage name="cardNumber"}}</span>
+          {{/if}}
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
+          {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
+          {{#if afFieldIsInvalid name="expireMonth"}}
+          <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
+          {{/if}}
+      </div>
+
+      <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
+          {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
+          {{#if afFieldIsInvalid name="expireYear"}}
+          <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
+          {{/if}}
+      </div>
+
+    </div>
+    <div class="row">
+      <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
+          <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
+          {{>afFieldInput name="cvv" placeholder="CVV"}}
+          {{#if afFieldIsInvalid name="cvv"}}
+          <span class="help-block">{{afFieldMessage name="cvv"}}</span>
+          {{/if}}
+      </div>
     </div>
 
-    <div class="form-group{{#if afFieldIsInvalid name='cardNumber'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='cardNumber'}}</label>
-        {{>afFieldInput name="cardNumber" placeholder='XXXX XXXX XXXX XXXX'}}
-        {{#if afFieldIsInvalid name="cardNumber"}}
-        <span class="help-block">{{afFieldMessage name="cardNumber"}}</span>
-        {{/if}}
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireMonth'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='expireMonth'}}</label>
-        {{>afFieldInput name="expireMonth" options=(monthOptions false) firstOption=(i18n "app.monthOptions" "Choose month") placeholder="Exp. Month"}}
-        {{#if afFieldIsInvalid name="expireMonth"}}
-        <span class="help-block">{{afFieldMessage name="expireMonth"}}</span>
-        {{/if}}
-    </div>
+    <div class="alert alert-danger hidden">Oh! Snap!</div>
+    <button type="submit" class="rui btn btn-lg btn-cta btn-block btn-complete-order">
+      <span id="btn-complete-order" data-i18n="checkoutPayment.completeYourOrder">Complete your order</span>
+      <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
+    </button>
 
-    <div class="col-sm-12 col-lg-6 form-group{{#if afFieldIsInvalid name='expireYear'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='expireYear'}}</label>
-        {{>afFieldInput name="expireYear" options=(yearOptions false) firstOption=(i18n "app.yearOptions" "Choose year") placeholder="Exp. Year"}}
-        {{#if afFieldIsInvalid name="expireYear"}}
-        <span class="help-block">{{afFieldMessage name="expireYear"}}</span>
-        {{/if}}
-    </div>
-
-  </div>
-  <div class="row">
-    <div class="col-sm-12 col-lg-3 form-group{{#if afFieldIsInvalid name='cvv'}} has-error{{/if}}">
-        <label class="control-label">{{afFieldLabelText name='cvv'}}</label>
-        {{>afFieldInput name="cvv" placeholder="CVV"}}
-        {{#if afFieldIsInvalid name="cvv"}}
-        <span class="help-block">{{afFieldMessage name="cvv"}}</span>
-        {{/if}}
-    </div>
-  </div>
-
-  <div class="alert alert-danger hidden">Oh! Snap!</div>
-  <button type="submit" class="rui btn btn-lg btn-cta btn-block btn-complete-order">
-    <span id="btn-complete-order" data-i18n="checkoutPayment.completeYourOrder">Complete your order</span>
-    <i class="fa fa-spinner fa-spin hidden" id="btn-processing"></i>
-  </button>
-
-  {{/autoForm}}
+    {{/autoForm}}
+  {{/if}}
 </template>

--- a/imports/plugins/included/payments-stripe/client/checkout/stripe.js
+++ b/imports/plugins/included/payments-stripe/client/checkout/stripe.js
@@ -1,6 +1,7 @@
 /* eslint camelcase: 0 */
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
+import { ReactiveVar } from "meteor/reactive-var";
 import { AutoForm } from "meteor/aldeed:autoform";
 import { $ } from "meteor/jquery";
 import { getCardType } from "/client/modules/core/helpers/globals";
@@ -72,6 +73,16 @@ function validCVV(x) {
 Template.stripePaymentForm.helpers({
   StripePayment() {
     return StripePayment;
+  },
+
+  formVisibility() {
+    return Template.instance().formVisibility.get();
+  }
+});
+
+Template.stripePaymentForm.events({
+  "click #toggleForm": (event, template) => {
+    template.formVisibility.set(!template.formVisibility.get());
   }
 });
 
@@ -91,6 +102,7 @@ Template.stripePaymentForm.onCreated(function () {
       }
     }
   });
+  this.formVisibility = new ReactiveVar(false);
 });
 
 //


### PR DESCRIPTION
#### What does this PR do?
Add popup confirmation before any transaction
Add a button to toggle payment form in the checkout page
#### Description of Task to be completed?
Add popup confirmation before any transaction
#### How should this be manually tested?
- clone the repo and change into the project directory
- start the application(instructions in the readme)
- visit the application in the browser 
- login/signup as a user
- visit your profile
- try transferring some fund to another customer
- a pop-up should show before the actual transaction
- try to also make payment with your wallet
- a pop-up should show before the actual transaction
- on the checkout page
- the payment option should display as button, 
- when you click on them, the actual payment form should be displayed
#### What are the relevant pivotal tracker stories?
#157626915
#### Screenshots 
<img width="1143" alt="screen shot 2018-05-18 at 9 17 10 am" src="https://user-images.githubusercontent.com/26048536/40223898-76da5d5e-5a7c-11e8-9796-5e931805ba6c.png">
<img width="1177" alt="screen shot 2018-05-18 at 9 17 38 am" src="https://user-images.githubusercontent.com/26048536/40223929-88fdea46-5a7c-11e8-9b96-614f417604cf.png">
<img width="524" alt="screen shot 2018-05-18 at 9 17 49 am" src="https://user-images.githubusercontent.com/26048536/40223944-917d3014-5a7c-11e8-8666-35ba45c5b909.png">
<img width="527" alt="screen shot 2018-05-18 at 9 21 58 am" src="https://user-images.githubusercontent.com/26048536/40224089-ffd3355e-5a7c-11e8-8d11-a5da13da8514.png">




