### PR TITLE
#157032085 feature(static page management): add static pages

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -95,3 +95,4 @@ johanbrook:publication-collector
 
 # Custom Packages
 react-template-helper
+teamon:tinymce

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -152,6 +152,7 @@ shell-server@0.2.4
 spacebars@1.0.15
 spacebars-compiler@1.1.3
 srp@1.0.10
+teamon:tinymce@4.5.4
 templating@1.3.2
 templating-compiler@1.3.3
 templating-runtime@1.3.2

--- a/imports/plugins/core/accounts/client/components/staticPages.js
+++ b/imports/plugins/core/accounts/client/components/staticPages.js
@@ -1,0 +1,48 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { registerComponent } from "@reactioncommerce/reaction-components";
+import { Reaction } from "/lib/api";
+
+class StaticPagesComponent extends Component {
+  static propTypes = {
+    pages: PropTypes.array
+  };
+  goToStaticPage(page) {
+    return Reaction.Router.go(`/pages/${page.pageAddress}`);
+  }
+
+  renderStaticPagesComponent() {
+    const { pages } = this.props;
+    return (
+      <div className="static-pages dropdown" role="menu" data-delay="1000">
+        <div className="dropdown-toggle tog" data-toggle="dropdown">
+          About
+          <span className="caret" />
+        </div>
+        <ul className="dropdown-menu">
+          {pages.map(page => {
+            return (
+              <li key={page._id}>
+                <a className="static-dropdown" onClick={() => this.goToStaticPage(page)}>
+                  {page.pageName}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div className="static-pages" role="menu">
+        {this.renderStaticPagesComponent()}
+      </div>
+    );
+  }
+}
+
+registerComponent("StaticPagesComponent", StaticPagesComponent);
+
+export default StaticPagesComponent;

--- a/imports/plugins/core/accounts/client/containers/staticPages.js
+++ b/imports/plugins/core/accounts/client/containers/staticPages.js
@@ -1,0 +1,29 @@
+import { compose, withProps } from "recompose";
+import { Reaction } from "/client/api";
+import { Meteor } from "meteor/meteor";
+import { registerComponent, composeWithTracker } from "@reactioncommerce/reaction-components";
+import * as Collections from "/lib/collections";
+import StaticPagesComponent from "../components/staticPages";
+
+const handlers = {};
+
+const composer = (props, onData) => {
+  const subscription = Meteor.subscribe("StaticPages");
+  let pages = [];
+  if (subscription.ready()) {
+    pages = Collections.StaticPages.find({
+      shopId: Reaction.getShopId(),
+      isEnabled: true
+    }).fetch();
+  }
+
+  if (pages.length > 0) {
+    onData(null, { pages });
+  } else {
+    onData(null, { pages });
+  }
+};
+
+registerComponent("StaticPagesComponent", StaticPagesComponent, [composeWithTracker(composer), withProps(handlers)]);
+
+export default compose(composeWithTracker(composer), withProps(handlers))(StaticPagesComponent);

--- a/imports/plugins/core/accounts/client/index.js
+++ b/imports/plugins/core/accounts/client/index.js
@@ -28,6 +28,7 @@ export { default as MainDropdownContainer } from "./containers/mainDropdown";
 export { default as MessagesContainer } from "./containers/messages";
 export { default as UpdatePasswordOverlayContainer } from "./containers/passwordOverlay";
 export { default as LoginInlineContainer } from "./containers/loginInline";
+export { default as StaticPages } from "./components/staticPages";
 
 import "./templates/accounts.html";
 
@@ -62,3 +63,5 @@ import "./templates/verify/verifyAccount.html";
 import "./templates/verify/verifyAccount.js";
 import "./templates/wallet/wallet.html";
 import "./templates/wallet/wallet.js";
+import "./templates/staticPagesNav/staticPagesNav.html";
+import "./templates/staticPagesNav/staticPagesNav.js";

--- a/imports/plugins/core/accounts/client/templates/staticPagesNav/staticPagesNav.html
+++ b/imports/plugins/core/accounts/client/templates/staticPagesNav/staticPagesNav.html
@@ -1,0 +1,5 @@
+<template name="staticPagesNav">
+    <div>
+    {{>React staticPages}}
+    </div>
+</template>

--- a/imports/plugins/core/accounts/client/templates/staticPagesNav/staticPagesNav.js
+++ b/imports/plugins/core/accounts/client/templates/staticPagesNav/staticPagesNav.js
@@ -1,0 +1,10 @@
+import { Template } from "meteor/templating";
+import StaticPagesContainer from "../../containers/staticPages";
+
+Template.staticPagesNav.helpers({
+  staticPages() {
+    return {
+      component: StaticPagesContainer
+    };
+  }
+});

--- a/imports/plugins/core/staticPage/client/index.js
+++ b/imports/plugins/core/staticPage/client/index.js
@@ -1,0 +1,2 @@
+import "./templates/staticPage.html";
+import "./templates/staticPage.js";

--- a/imports/plugins/core/staticPage/client/templates/staticPage.html
+++ b/imports/plugins/core/staticPage/client/templates/staticPage.html
@@ -1,0 +1,13 @@
+<template name="staticPageView">
+    {{#each pageDetail in staticPage pageAddress}}
+    <div class="section">
+    <h2 class="static-title">{{pageDetail.title}}</h2>
+    <hr/>
+    <div class='row'>
+        <div class="col-md-10 col-md-offset-1">
+        {{{pageDetail.content}}}
+        </div>
+    </div>
+    </div>
+    {{/each}}
+</template>

--- a/imports/plugins/core/staticPage/client/templates/staticPage.js
+++ b/imports/plugins/core/staticPage/client/templates/staticPage.js
@@ -1,0 +1,19 @@
+import { StaticPages } from "/lib/collections";
+import { Template } from "meteor/templating";
+import { Meteor } from "meteor/meteor";
+import { Router } from "/client/api";
+
+Template.staticPageView.helpers({
+  staticPage() {
+    const current = Router.current();
+    const pageAddress = current.params.pageAddress;
+    const subscription = Meteor.subscribe("StaticPages");
+    if (subscription.ready()) {
+      const page = StaticPages.find({ pageAddress }).fetch();
+      if (page.length > 0) {
+        const pageContent = page[0].pageContent;
+        return [{ title: page[0].pageName, content: pageContent }];
+      }
+    }
+  }
+});

--- a/imports/plugins/core/staticPage/register.js
+++ b/imports/plugins/core/staticPage/register.js
@@ -1,0 +1,36 @@
+import { Reaction } from "/server/api";
+
+Reaction.registerPackage({
+  label: "Static-Page-View",
+  name: "reaction-static-pages-view",
+  autoEnable: true,
+  registry: [
+    {
+      route: "/pages/:pageAddress",
+      name: "pages",
+      permissions: ["admin", "guest", "anonymous"],
+      audience: ["anonymous", "guest"],
+      workflow: "coreStaticPagesWorkflow",
+      template: "staticPageView"
+    }
+  ],
+  layout: [
+    {
+      layout: "coreLayout",
+      workflow: "coreProductWorkflow",
+      collection: "StaticPages",
+      theme: "default",
+      enabled: true,
+      structure: {
+        template: "staticPageView",
+        layoutHeader: "layoutHeader",
+        layoutFooter: "",
+        notFound: "productNotFound",
+        dashboardHeader: "productDetailSimpleToolbar",
+        dashboardControls: "productDetailDashboardControls",
+        dashboardHeaderControls: "",
+        adminControlsFooter: "adminControlsFooter"
+      }
+    }
+  ]
+});

--- a/imports/plugins/core/staticPages/client/index.js
+++ b/imports/plugins/core/staticPages/client/index.js
@@ -1,0 +1,2 @@
+import "./templates/staticPages.html";
+import "./templates/staticPages.js";

--- a/imports/plugins/core/staticPages/client/templates/staticPages.html
+++ b/imports/plugins/core/staticPages/client/templates/staticPages.html
@@ -1,0 +1,83 @@
+<template name="staticPages">
+    <div class='container'>
+        <div class='row'>
+        <div class='col-lg-12 col-xs-12'>
+            <h1>Manage Pages</h1>
+            {{> staticPagesPanel}}
+        </div>
+        <div class='col-lg-12 col-xs-12'>
+            <h1>Create Pages</h1>
+            {{> staticPagesForm}}
+        </div>
+        </div>
+    </div>
+</template>
+
+<template name="staticPagesPanel">
+    <div class="static-page-panel panel panel-info">
+        <div class="panel-body">
+        {{#if staticPages.count}}
+        <div class="table-responsive">
+            <table class="table table-hover">
+            <thead>
+                <tr>
+                <th>Page Name</th>
+                <th>Page Address</th>
+                <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{#each page in staticPages}}
+                <tr id={{page._id}}>
+                <td>{{page.pageName}}</td>
+                <td>{{page.pageAddress}}</td>
+                <td>
+                    <div class='btn-group'>
+                    <button type="button" class="btn btn-info editPage">Edit
+                        <i class="fa fa-edit"></i>
+                    </button>
+                    <button type="button" class="btn btn-danger deletePage">Delete
+                        <i class="fa fa-trash"></i>
+                    </button>
+                    <a href="/pages/{{page.pageAddress}}" type="button" class="btn btn-default">Preview
+                        <i class="fa fa-eye"></i>
+                    </a>
+                    </div>
+                </td>
+                </tr>
+                {{/each}}
+            </tbody>
+            </table>
+        </div>
+        {{else}}
+        <div class='alert alert-info text-center'>
+            <h4>Oops! No pages have been added.</h4>
+        </div>
+        {{/if}}
+        </div>
+    </div>
+</template>
+
+<template name="staticPagesForm">
+    <form class="static-page">
+        <div class="form-group label-info">
+        <label for="sp-name">Page Title:</label>
+        <input type="text" name="name" id="sp-name" placeholder="Enter page name.. (e.g. Contact)" class="form-control" required="required">
+        </div>
+        <div class="form-group label-info">
+        <label for="sp-url">Page URL Address:</label>
+        <input type="text" name="url" id="sp-url" placeholder="Enter page address.. (e.g. 'contact')" class="form-control" required="required">
+        <input class="edit-page-data" type='hidden'>
+        </div>
+        <div class="form-group label-info">
+        <label for="sp-content">Create your page below:</label>
+        <textarea name="content" id="sp-content" class="form-control spform"></textarea>
+        </div>
+        <div class="checkbox form-group label-info">
+        <label>
+            <input type="checkbox" name="showOnNavbar" id="sp-show">Show page on navbar?
+        </label>
+        </div>
+        <button type="submit" class="form-group save-static-page btn btn-default">Create Page</button>
+    </form>
+</template>

--- a/imports/plugins/core/staticPages/client/templates/staticPages.js
+++ b/imports/plugins/core/staticPages/client/templates/staticPages.js
@@ -1,0 +1,177 @@
+import { Reaction } from "/client/api";
+import { Template } from "meteor/templating";
+import { $ } from "meteor/jquery";
+import { Meteor } from "meteor/meteor";
+import { StaticPages } from "/lib/collections";
+
+Template.staticPages.onRendered(() => {
+  /* global tinymce */
+  tinymce.init({
+    selector: "textarea.spform",
+    height: 500,
+    theme: "modern",
+    skin_url: "/packages/teamon_tinymce/skins/lightgray", // eslint-disable-line
+    plugins: `print preview fullpage searchreplace
+        autolink directionality visualblocks visualchars fullscreen
+        image link media template codesample table charmap hr pagebreak nonbreaking
+        anchor toc insertdatetime advlist lists textcolor
+        wordcount imagetools contextmenu colorpicker textpattern`,
+    toolbar1: `formatselect | bold italic strikethrough forecolor backcolor | link
+      | alignleft aligncenter alignright alignjustify  | numlist bullist outdent indent  | removeformat`
+  });
+});
+
+Template.staticPagesPanel.onCreated(function () {
+  this.autorun(() => {
+    this.subscribe("StaticPages");
+  });
+});
+
+Template.staticPagesPanel.helpers({
+  staticPages() {
+    const instance = Template.instance();
+    if (instance.subscriptionsReady()) {
+      return StaticPages.find({
+        shopId: Reaction.getShopId()
+      });
+    }
+  }
+});
+
+Template.staticPagesPanel.events({
+  "click .deletePage"(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    // confirm delete
+    Alerts.alert(
+      {
+        title: "Remove Static Page?",
+        type: "warning",
+        showCancelButton: true,
+        cancelButtonText: "No",
+        confirmButtonText: "Yes"
+      },
+      confirmed => {
+        if (confirmed) {
+          const _id = $(event.currentTarget)
+            .parents("tr")
+            .attr("id");
+          Meteor.call("deletePage", _id);
+        }
+        return false;
+      }
+    );
+  },
+
+  "click .editPage"(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    // Get ID of the page and then retrieve from the database
+    const _id = $(event.currentTarget)
+      .parents("tr")
+      .attr("id");
+    const pageDetails = StaticPages.find({ _id }).fetch();
+
+    // Set the page form to values gotten from the form for editing
+    $(".static-page")
+      .find("#sp-name")
+      .val(pageDetails[0].pageName);
+    $(".static-page")
+      .find("#sp-url")
+      .val(pageDetails[0].pageAddress);
+    $(".static-page")
+      .find("#sp-show")
+      .prop("checked", pageDetails[0].isEnabled === true ? true : false);
+    $(".static-page")
+      .find(".edit-page-data")
+      .attr("id", pageDetails[0]._id);
+    tinymce.activeEditor.setContent(pageDetails[0].pageContent);
+    $(".static-page")
+      .find(".save-static-page")
+      .html("Update Page");
+
+    // Focus section of page to the form
+    $("#main").animate(
+      {
+        scrollTop: $(".static-page").offset().top
+      },
+      800
+    );
+  }
+});
+
+Template.staticPagesForm.events({
+  "submit form": event => {
+    event.preventDefault();
+    const field = event.target;
+    const pageName = field.name.value;
+    const pageAddress = field.url.value;
+    const pageContent = field.content.value;
+    const isEnabled = $("#sp-show").is(":checked") ? true : false;
+    const userId = Meteor.userId();
+    const shopId = Reaction.getShopId();
+    let createdAt = new Date();
+    const updatedAt = new Date();
+
+    if (
+      $(".static-page")
+        .find(".edit-page-data")
+        .attr("id") === undefined
+    ) {
+      Meteor.call("insertPage", pageName, pageAddress, pageContent, userId, shopId, isEnabled, createdAt, function (
+        err
+      ) {
+        if (err) {
+          Alerts.toast(err.message, "error");
+        } else {
+          Alerts.toast("Page Successfully Created", "success");
+        }
+      });
+    } else {
+      const _id = $(".static-page")
+        .find(".edit-page-data")
+        .attr("id");
+      const pageDetails = StaticPages.find({ _id }).fetch();
+      if (pageDetails.length > 0) {
+        createdAt = pageDetails[0].createdAt;
+        // Update the data in the database
+        Meteor.call(
+          "updatePage",
+          _id,
+          pageName,
+          pageAddress,
+          pageContent,
+          userId,
+          shopId,
+          isEnabled,
+          createdAt,
+          updatedAt,
+          function (err) {
+            if (err) {
+              Alerts.toast(err.message, "error");
+            } else {
+              Alerts.toast("Page Successfully Modified", "success");
+            }
+          }
+        );
+      } else {
+        Alerts.toast("Oops! Page Not Found, Please create a new Static Page", "error");
+      }
+      $(".static-page")
+        .find(".edit-page-data")
+        .attr("id", "");
+      $(".static-page")
+        .find(".save-static-page")
+        .html("Create Page");
+    }
+
+    field.name.value = "";
+    field.url.value = "";
+    tinymce.activeEditor.setContent("");
+    $(".static-page")
+      .find("#sp-show")
+      .prop("checked", false);
+  }
+});

--- a/imports/plugins/core/staticPages/register.js
+++ b/imports/plugins/core/staticPages/register.js
@@ -1,0 +1,50 @@
+import { Reaction } from "/server/api";
+
+Reaction.registerPackage({
+  label: "Static Pages",
+  name: "staticPages",
+  icon: "fa fa-file",
+  autoEnable: true,
+  settings: {
+    name: "Static Pages"
+  },
+  registry: [
+    {
+      provides: ["dashboard"],
+      route: "/dashboard/static",
+      name: "static-pages",
+      label: "Static Pages",
+      description: "Create static pages",
+      icon: "fa fa-file",
+      priority: 1,
+      container: "core",
+      workflow: "coreDashboardWorkflow",
+      permissions: [
+        {
+          label: "dashboard/static",
+          permission: "dashboard/static"
+        }
+      ],
+      template: "staticPages"
+    }
+  ],
+  layout: [
+    {
+      layout: "coreLayout",
+      workflow: "coreDashboardWorkflow",
+      collection: "StaticPages",
+      theme: "default",
+      enabled: true,
+      structure: {
+        template: "staticPages",
+        layoutHeader: "layoutHeader",
+        layoutFooter: "layoutFooter",
+        notFound: "notFound",
+        dashboardHeader: "dashboardHeader",
+        dashboardControls: "dashboardControls",
+        dashboardHeaderControls: "dashboardControls",
+        adminControlsFooter: "adminControlsFooter"
+      }
+    }
+  ]
+});

--- a/imports/plugins/core/ui-navbar/client/components/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/components/navbar.js
@@ -173,6 +173,12 @@ class NavBar extends Component {
     tourSetup.initManualTour();
   }
 
+  renderStaticPages() {
+    return (
+      <Components.StaticPagesComponent />
+    );
+  }
+
   render() {
     // console.log(this.props, 'no props here ')
     return (
@@ -184,6 +190,7 @@ class NavBar extends Component {
         {this.renderTourButton()}
         {this.renderNotificationIcon()}
         {this.renderOnboardingButton()}
+        {this.renderStaticPages()}
         {this.renderLanguage()}
         {this.renderCurrency()}
         {this.renderMainDropdown()}

--- a/imports/plugins/custom/casablanca-theme/client/styles/styles.less
+++ b/imports/plugins/custom/casablanca-theme/client/styles/styles.less
@@ -27,6 +27,13 @@
   color: @black;
 }
 
+.tog {
+  color: @white !important
+}
+
+.tog:hover {
+  color: @black !important
+}
 
 // The searh, notificaiton, language, currencies, accounts icon
 .rui.navbar {

--- a/imports/plugins/included/default-theme/client/styles/main.less
+++ b/imports/plugins/included/default-theme/client/styles/main.less
@@ -123,6 +123,7 @@
 @import "dashboard/orders.less";
 @import "dashboard/package.less";
 @import "dashboard/accounts.less";
+@import "staticPages/staticPages.less";
 @import "dashboard/settings.less";
 @import "dashboard/tables.less";
 @import "dashboard/widget.less";

--- a/imports/plugins/included/default-theme/client/styles/navbar.less
+++ b/imports/plugins/included/default-theme/client/styles/navbar.less
@@ -263,6 +263,172 @@ html:not(.rtl) .rui.navbar .languages .dropdown-menu {
   .left(auto);
 }
 
+.rui.navbar .static-pages {
+    .display(flex);
+    .align-items(center);
+    .flex(0 0 auto);
+    height: @navbar-height;
+  }
+  
+  .rui.navbar .static-pages:hover {
+    background-color: @navbar-default-toggle-icon-bar-bg;
+    border-color: @navbar-default-toggle-border-color;
+  }
+  
+  .rui.navbar .static-pages:active {
+    background-color: @navbar-default-toggle-icon-bar-bg;
+    border-color: @navbar-default-toggle-border-color;
+  }
+  
+  .rui.navbar .static-pages .dropdown-toggle {
+    .display(flex);
+    .align-items(center);
+    height: 100%;
+  
+    padding: 0 @navbar-padding-vertical;
+    .padding-left(@navbar-padding-vertical);
+  }
+  
+  .rui.navbar .static-pages .dropdown {
+    height: 100%;
+  }
+  
+  .rui.navbar .static-pages .additional-link-container a {
+    color: @link-color;
+  }
+  
+  .rui.navbar .static-pages .additional-link-container a:hover {
+    color: @link-hover-color;
+    background-color: transparent;
+  }
+  
+  .rui.navbar .static-pages .dropdown .circular-icon {
+    width: 40px;
+    height: 40px;
+    margin: -15px 5px;
+    border: 2px solid rgba(129, 122, 122, 0.62);
+    border-radius: 50%;
+    display: inline-block;
+  }
+  
+  .rui.navbar .static-pages .dropdown .circular-icon .avatar-initials {
+    line-height: 35px;
+  }
+  
+  .rui.navbar .static-pages .dropdown .user-accounts-dropdown {
+    padding: 10px;
+  }
+  
+  .rui.navbar .static-pages .dropdown .user-accounts-dropdown-content {
+    min-width: 220px;
+    min-height: 50px;
+    color: @gray-darker;
+  }
+  
+  .rui.navbar .static-pages .dropdown ul {
+      padding: 0;
+  }
+  
+  .rui.navbar .static-pages .dropdown .user-accounts-dropdown-apps {
+    margin: 0;
+  }
+  
+  .rui.navbar .static-pages .dropdown .user-accounts-dropdown-apps i {
+    margin: 10px 10px 10px 6px;
+    width: 20px;
+    font-size: inherit;
+    text-align: center;
+   }
+  
+  .rui.navbar .static-pages .dropdown .dropdown-apps-icon {
+    cursor: pointer;
+    white-space: nowrap;
+    display: block;
+    border-bottom: 1px solid @black10;
+  }
+  
+  .rui.navbar .static-pages .dropdown .dropdown-apps-icon:last-child {
+    border-bottom: none;
+  }
+  
+  .rui.navbar .static-pages .dropdown .dropdown-apps-icon a {
+    display: flex;
+    align-items: center;
+    color: @gray;
+    text-decoration: none;
+    padding: 5px 0;
+    min-height: 44px;
+  }
+  
+  .rui.navbar .static-pages .dropdown .dropdown-apps-icon a:hover,
+  .rui.navbar .static-pages .dropdown .dropdown-apps-icon a:focus {
+    color: @brand-vivid-color;
+    text-decoration: none;
+    background-color: transparent;
+  }
+  
+  .rui.navbar .static-pages .dropdown-menu {
+    border: 1px solid @dropdown-border;
+    margin-top: 0;
+    .right(0);
+    .left(auto);
+  }
+  
+  .static-pages-a-tag {
+    display: flex !important;
+    align-items: center;
+    text-decoration: none;
+    padding: 5px 0 !important;
+    min-height: 44px !important;
+    min-width: 220px;
+  }
+  
+  .static-pages-a-tag:hover,
+  .static-pages-a-tag:focus {
+    color: @brand-vivid-color !important;
+    text-decoration: none;
+    background-color: transparent !important;
+  }
+  
+  .static-pages-li-tag {
+    cursor: pointer;
+    white-space: nowrap;
+    display: block;
+    border-bottom: 1px solid @black10;
+  }
+  
+  .static-pages-li-tag:last-child {
+    border-bottom: none;
+  }
+  
+  .static-pages-btn-tag {
+    padding: 6px 12px !important;
+    color: #fff !important;
+    background-color: @btn-primary-bg !important;
+    color: @btn-primary-color !important;
+    border-color: @btn-primary-bg !important;
+  }
+  
+  .static-pages-btn-tag:hover {
+    background: darken(@btn-primary-bg, 5%) !important;
+  }
+  
+  .static-pages-img-tag {
+    width: 30px;
+    height: 30px;
+    margin: -15px 5px;
+    border: 2px solid rgba(129, 122, 122, 0.62);
+    border-radius: 50%;
+    display: inline-block;
+  }
+  
+  .static-pages-avatar {
+    .margin-right(10px);
+    border: solid rgba(129, 122, 122, 0.62) 2px;
+    box-sizing: content-box !important;
+  }
+  
+
 .rui.navbar .search {
   .display(flex);
   .align-items(center);

--- a/imports/plugins/included/default-theme/client/styles/staticPages/staticPages.less
+++ b/imports/plugins/included/default-theme/client/styles/staticPages/staticPages.less
@@ -1,0 +1,42 @@
+.label-info {
+      padding: 10px;
+      background-color: #fff;
+    }
+    
+    .alert-info {
+      background-color: #fff;
+      border-color: #fff;
+      color: rgb(0, 0, 0);
+    }
+    
+    .panel-info > .panel-heading {
+      color: rgb(0, 0, 0);
+      background-color: #fff;
+      border-color: #fff;
+    }
+    
+    .section {
+      box-shadow: 0px 10px 20px -10px #bebebe;
+      padding: 30px;
+      background-color: white;
+      margin-right: 80px;
+      margin-left: 80px;
+      margin-top: 30px;
+      margin-bottom: 60px;
+    }
+    
+    .static-title {
+      color: @cart-icon-bg;
+      text-align: center;
+    }
+    
+    .static-dropdown:hover,
+    .static-dropdown:focus {
+      color: @brand-vivid-color !important;
+      text-decoration: none;
+      background-color: transparent !important;
+    }
+    
+    .static-page {
+      margin-bottom: 2rem;
+    }

--- a/imports/plugins/included/footer/client/templates/footer.html
+++ b/imports/plugins/included/footer/client/templates/footer.html
@@ -21,9 +21,9 @@
             <div class="col-sm-3">
               <h4 class="title">Get To Know us</h4>
               <div class="category">
-              <a href="#">About Us</a>
-              <a href="#">Contact</a>
-              <a href="#">Terms & Conditions</a>
+              <a href="pages/about">About Us</a>
+              <a href="/pages/contact">Contact</a>
+              <a href="/pages/terms">Terms & Conditions</a>
               </div>
               </div>
 

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -187,6 +187,12 @@ export const Notifications = new Mongo.Collection("Notifications");
 
 Notifications.attachSchema(Schemas.Notification);
 
+/**
+ * StaticPages Collection
+ */
+export const StaticPages = new Mongo.Collection("StaticPages");
+
+StaticPages.attachSchema(Schemas.StaticPages);
 
 /**
  * Sms Collection

--- a/lib/collections/schemas/index.js
+++ b/lib/collections/schemas/index.js
@@ -22,5 +22,6 @@ export * from "./social";
 export * from "./tags";
 export * from "./templates";
 export * from "./themes";
+export * from "./staticPages";
 export * from "./translations";
 export * from "./workflow";

--- a/lib/collections/schemas/staticPages.js
+++ b/lib/collections/schemas/staticPages.js
@@ -1,0 +1,57 @@
+
+import { SimpleSchema } from "meteor/aldeed:simple-schema";
+import { Random } from "meteor/random";
+import { registerSchema } from "@reactioncommerce/reaction-collections";
+
+/**
+ * Reaction Schemas StaticPages
+ */
+export const StaticPages = new SimpleSchema({
+  _id: {
+    type: String,
+    defaultValue: Random.id(),
+    optional: true
+  },
+  pageName: {
+    label: "Page Name",
+    type: String
+  },
+  pageAddress: {
+    label: "Page URL Address",
+    type: String
+  },
+  pageContent: {
+    label: "Page Content",
+    type: String
+  },
+  userId: {
+    label: "User Identification",
+    type: String
+  },
+  shopId: {
+    label: "Shop Identification",
+    type: String
+  },
+  isEnabled: {
+    label: "Show page link on nav bar.",
+    type: Boolean,
+    defaultValue: false
+  },
+  createdAt: {
+    type: Date,
+    autoValue: function () {
+      if (this.isInsert) {
+        return new Date();
+      }
+      return {
+        $setOnInsert: new Date()
+      };
+    }
+  },
+  updatedAt: {
+    type: Date,
+    optional: true
+  }
+});
+
+registerSchema("StaticPages", StaticPages);

--- a/server/api/core/core.js
+++ b/server/api/core/core.js
@@ -67,8 +67,8 @@ export default {
     const registeredPackage = this.Packages[packageInfo.name] = packageInfo;
     return registeredPackage;
   },
-  defaultCustomerRoles: [ "guest", "account/profile", "product", "tag", "index", "cart/checkout", "cart/completed", "shops"],
-  defaultVisitorRoles: ["anonymous", "guest", "product", "tag", "index", "cart/checkout", "cart/completed", "shops"],
+  defaultCustomerRoles: [ "guest", "account/profile", "product", "tag", "index", "cart/checkout", "psges", "cart/completed", "shops"],
+  defaultVisitorRoles: ["anonymous", "guest", "product", "tag", "index", "cart/checkout", "pages", "cart/completed", "shops"],
   createGroups,
   /**
    * canInviteToGroup

--- a/server/methods/core/staticPages.js
+++ b/server/methods/core/staticPages.js
@@ -1,0 +1,61 @@
+import * as Collections from "/lib/collections";
+import * as Schemas from "../../../lib/collections/schemas";
+import { StaticPages } from "../../../lib/collections";
+import { Meteor } from "meteor/meteor";
+import { check } from "meteor/check";
+
+Meteor.methods({
+  insertPage: function (pageName, pageAddress, pageContent, userId, shopId, isEnabled, createdAt) {
+    check(pageName, String);
+    check(pageAddress, String);
+    check(pageContent, String);
+    check(userId, String);
+    check(shopId, String);
+    check(isEnabled, Boolean);
+    check(createdAt, Date);
+
+    const page = {
+      pageName,
+      pageAddress,
+      pageContent,
+      userId,
+      shopId,
+      isEnabled,
+      createdAt
+    };
+
+    check(page, Schemas.StaticPages);
+    Collections.StaticPages.insert(page);
+  },
+  updatePage: function (_id, pageName, pageAddress, pageContent, userId, shopId, isEnabled, createdAt, updatedAt) {
+    check(_id, String);
+    check(pageName, String);
+    check(pageAddress, String);
+    check(pageContent, String);
+    check(userId, String);
+    check(shopId, String);
+    check(isEnabled, Boolean);
+    check(createdAt, Date);
+    check(updatedAt, Date);
+
+    const page = {
+      pageName,
+      pageAddress,
+      pageContent,
+      userId,
+      shopId,
+      isEnabled,
+      createdAt,
+      updatedAt
+    };
+
+    check(page, Schemas.StaticPages);
+    Collections.StaticPages.update(_id, { $set: page });
+  },
+
+  // deletePage: function
+  deletePage(_id) {
+    check(_id, String);
+    StaticPages.remove(_id);
+  }
+});

--- a/server/publications/collections/staticPages.js
+++ b/server/publications/collections/staticPages.js
@@ -1,0 +1,17 @@
+
+import { StaticPages } from "/lib/collections";
+import { Reaction } from "/server/api";
+import { Meteor } from "meteor/meteor";
+
+/**
+ * Static Pages
+ */
+Meteor.publish("StaticPages", function () {
+  const shopId = Reaction.getShopId();
+  if (!shopId) {
+    return this.ready();
+  }
+  return StaticPages.find({
+    shopId
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

- implements Static pages management
- add static page folder containing component and container
- add static pages folder containing component and container
- add style to style.less file
- add static page field to collections schema

#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run `meteor npm install` to install project dependencies
* run `npm install ImageMagick`
* run `reaction` to start up the app
* click on the about icon 

#### What are the relevant pivotal tracker stories? (if applicable)
157032085

#### Screenshot(s)
![screencapture-localhost-3000-pages-about-2018-05-22-12_23_44](https://user-images.githubusercontent.com/32877552/40359543-0fcd76f4-5dbb-11e8-9657-dabf061de703.png)
![screencapture-localhost-3000-pages-contact-2018-05-22-12_18_44](https://user-images.githubusercontent.com/32877552/40359544-0ff53b4e-5dbb-11e8-8445-b47f6d9e32d8.png)
![screencapture-localhost-3000-pages-terms-2018-05-22-12_18_23](https://user-images.githubusercontent.com/32877552/40359545-101ca724-5dbb-11e8-849a-e700b3f2788a.png)
<img width="1280" alt="screen shot 2018-05-22 at 12 26 44 pm" src="https://user-images.githubusercontent.com/32877552/40359690-875ebcb4-5dbb-11e8-9389-153d326be743.png">
