### PR TITLE
bug(font and button): make search page font consitent

### DIFF
--- a/imports/plugins/included/default-theme/client/styles/search/results.less
+++ b/imports/plugins/included/default-theme/client/styles/search/results.less
@@ -227,6 +227,9 @@
     margin-left: 20px;
   }
 
+  .sort-size {
+    font-weight: 100 !important;
+  }
   .sort-div, .filter {
     margin-bottom: 20px;
   }

--- a/imports/plugins/included/ui-search/lib/components/searchModal.js
+++ b/imports/plugins/included/ui-search/lib/components/searchModal.js
@@ -41,6 +41,7 @@ class SearchModal extends Component {
           i18nKeyLabel="search.clearSearch"
           label="Clear"
           containerStyle={{ fontWeight: "normal" }}
+          style={{ top: 29 }}
           onClick={this.props.handleClick}
         />
       </div>
@@ -138,7 +139,7 @@ class SearchModal extends Component {
               <div id="sort">
                 <div className="container sort-filter">
                   <div className="sort-div">
-                    <label>Sort by New Arrivals</label>
+                    <label className="sort-size">Sort by New Arrivals</label>
                     <div className="rui select">
                       <select
                         id="sort-value"
@@ -151,7 +152,7 @@ class SearchModal extends Component {
                     </div>
                   </div>
                   <div className="sort-div">
-                    <label>Sort by BestSellers</label>
+                    <label className="sort-size">Sort by BestSellers</label>
                     <div className="rui select">
                       <select
                         id="sort-value"
@@ -164,7 +165,7 @@ class SearchModal extends Component {
                     </div>
                   </div>
                   <div className="sort-div">
-                    <label>Filter by Ratings</label>
+                    <label className="sort-size">Filter by Ratings</label>
                     <div className="container">
                       <span>
                         <a
@@ -178,7 +179,6 @@ class SearchModal extends Component {
                           />
                         </a>
                       </span>
-
                       <span>
                         <a
                           onClick={() => this.props.handleRatingChange("3-4")}
@@ -231,7 +231,7 @@ class SearchModal extends Component {
                     </div>
                   </div>
                   <div className="filter">
-                    <label className="transform">Filter by Price</label>
+                    <label className="sort-size">Filter by Price</label>
                     <div className="rui select">
                       <select
                         id="price-filter"
@@ -247,7 +247,7 @@ class SearchModal extends Component {
                     </div>
                   </div>
                   <div className="sort-div">
-                    <label>Filter by Vendor </label>
+                    <label className="sort-size">Filter by Vendor </label>
                     {this.renderVendor()}
                   </div>
                 </div>


### PR DESCRIPTION
add margin to search input area clear button

[finishes #157848169]

#### What does this PR do?
* This PR improves the UI for the clear button and makes the font on the sort area consistent with the rest of the page
#### Description of Task to be completed?
* add margin to search input area clear button
* give sort and filter description lighter font weight

#### How should this be manually tested?
* clone this repo
* cd into the project folder
* run `meteor npm install` to install project dependencies
* run `npm install ImageMagick`
* run `reaction` to start up the app
* click on the search icon
* the clear button should be padded away from the search input field
* the font on the sort and filter area should be consistent with the rest of the page
#### What are the relevant pivotal tracker stories? (if applicable)
 #157848169

Screenshots
<img width="1440" alt="screen shot 2018-05-24 at 4 53 31 pm" src="https://user-images.githubusercontent.com/29184825/40497445-1b8774da-5f74-11e8-9e7c-9d6612f14793.png">
