### PR TITLE
#157844092 Show the status of an order in its details

### DIFF
--- a/imports/plugins/core/checkout/client/components/completedOrder.js
+++ b/imports/plugins/core/checkout/client/components/completedOrder.js
@@ -46,9 +46,28 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
     );
   }
 
+  const getOrderStatus = (theOrder) => {
+    const workflowStatus = theOrder.workflow.status;
+    const status = { text: null, color: "grey" };
+    if (workflowStatus === "new") {
+      status.text = "This order has not been processed";
+      status.color = "order-new";
+    } else if (workflowStatus === "coreOrderWorkflow/processing") {
+      status.text = "This order is being processed";
+      status.color = "order-processed";
+    } else if (workflowStatus === "coreOrderWorkflow/completed") {
+      status.text = "This order is already shipped";
+      status.color = "order-shipped";
+    } else if (workflowStatus === "coreOrderWorkflow/canceled") {
+      status.text = "This order is canceled";
+      status.color = "order-canceled";
+    }
+    return status;
+  };
+
   return (
     <div className="container order-completed">
-      { headerText }
+      {headerText}
       <div className="order-details-main">
         <div className="order-details-content-title">
           <p><Components.Translation defaultValue="Your Items" i18nKey={"cartCompleted.yourItems"} /></p>
@@ -81,8 +100,8 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
                 return <div className="order-details-info-box" key={shipment._id}>
                   <div className="order-details-info-box-content">
                     <p>
-                      {shipment.address.fullName}<br/>
-                      {shipment.address.address1}<br/>
+                      {shipment.address.fullName}<br />
+                      {shipment.address.address1}<br />
                       {shipment.address.city}, {shipment.address.region} {shipment.address.postal} {shipment.address.country}
                     </p>
                   </div>
@@ -102,13 +121,20 @@ const CompletedOrder = ({ order, orderId, shops, orderSummary, paymentMethods, h
         </div>
         <CompletedOrderSummary shops={shops} orderSummary={orderSummary} isProfilePage={isProfilePage} />
         {/* This is the right side / side content */}
-
-        {
-          isProfilePage && order.workflow.status === "coreOrderWorkflow/canceled" ?
-            <button className="rui btn btn-info" type="button" id="order-canceled-btn" disabled>This order is canceled</button> :
-            <button className="rui btn" type="button" id="cancel-order-btn" onClick={() => cancelOrder(order)}>Cancel Order</button>
-        }
-
+        <div className="order-status-info">
+          {
+            isProfilePage ?
+              <p className="rui order-status-text">
+                <span className={`order-status-dot ${getOrderStatus(order).color}`} />&nbsp;&nbsp;{getOrderStatus(order).text}
+              </p> :
+              null
+          }
+          {
+            isProfilePage && order.workflow.status !== "coreOrderWorkflow/canceled" ?
+              <button className="rui btn cancel-order-btn" type="button" onClick={() => cancelOrder(order)}>Cancel Order</button> :
+              null
+          }
+        </div>
       </div>
 
     </div>

--- a/imports/plugins/custom/casablanca-theme/client/styles/styles.less
+++ b/imports/plugins/custom/casablanca-theme/client/styles/styles.less
@@ -212,17 +212,66 @@
   .order-completed {
     padding-bottom: 25px;
   }
-  #cancel-order-btn {
-    margin-top: 15px;
-    background-color: white;
-    color: black;
-    border: 1px solid grey;
-    &:hover, &:active, &:focus {
-      background-color: #e6e6e6;
+  .order-status-info {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    .order-status-text {
+      margin-top: 15px;
+      background-color: white;
+      color: black;
+      border: 1px solid #ccc;
+      height: 40px;
+      font-size: 14px;
+      text-align: center;
+      padding: 7px;
     }
-  }
-  #order-canceled-btn {
-    margin-top: 15px;
+    .order-status-dot {
+      height: 10px;
+      width: 10px;
+      background-color: @casablanca-blue;
+      border-radius: 50%;
+      display: inline-block;
+      &.order-new {
+        background-color: grey;
+      }
+      &.order-processed {
+        background-color: @casablanca-orange;
+      }
+      &.order-shipped {
+        background-color: @casablanca-blue
+      }
+      &.order-canceled {
+        background-color: red;
+      }
+    }
+    .cancel-order-btn {
+      margin-top: 15px;
+      background-color: white;
+      color: black;
+      border: 1px solid @casablanca-blue;
+      &:hover, &:active, &:focus {
+        background-color: #e6e6e6;
+      }
+    }
   }
 }
 /* Orders list */
+
+/* Customizing sweet alert modal */
+div.swal2-container {
+  .swal2-modal .swal2-title {
+    font-size: 22px;
+  }
+}
+/* Customizing sweet alert modal */
+
+
+.core-payment-methods .core-payment-method-form {
+  .row:first-child {
+    padding-left: 5px;
+  }
+  #toggleForm {
+    margin-bottom: 10px;
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
- add a text-box that displays the status of an order at the bottom of the order summary
- add consistent-padding to the payment form on the checkout page
- reduce the font-size of sweet alert title
#### Description of Task to be completed?
Add the status of an order to the order details
#### How should this be manually tested?
- clone the repo and change into the project directory
- start the application(instructions in the readme)
- visit the application in the browser 
- login/signup as a user
##### Order Status 
- buy some products
- visit your profile
- you would see a list of all your orders 
- the status of a particular order should be displayed in the bottom of the order summary
##### Sweet Alert Title
- Try making a payment with your wallet
- An alert shold pop up to confirm the action 
- The font-size of the title of the alert shold be smaller
##### Consistent padding
- Inspect the payment form in the checkout page
- the padding around the inputs and select element should be consistent
#### What are the relevant pivotal tracker stories?
#157844092
#### Screenshots
 Order Status 
<img width="924" alt="screen shot 2018-05-25 at 11 33 14 am" src="https://user-images.githubusercontent.com/26048536/40540336-ab682554-600f-11e8-8285-a60d90467502.png">
<img width="846" alt="screen shot 2018-05-25 at 11 33 51 am" src="https://user-images.githubusercontent.com/26048536/40540351-c44efa48-600f-11e8-98a1-213b2c81fd92.png">
<img width="822" alt="screen shot 2018-05-25 at 11 33 35 am" src="https://user-images.githubusercontent.com/26048536/40540364-d4a40528-600f-11e8-93dd-142dcfd96cea.png">   
 Sweet Alert Title
<img width="903" alt="screen shot 2018-05-25 at 11 41 30 am" src="https://user-images.githubusercontent.com/26048536/40540741-172320ae-6011-11e8-8a1f-07644d04b0cf.png">  
Consistent padding
<img width="458" alt="screen shot 2018-05-25 at 11 43 40 am" src="https://user-images.githubusercontent.com/26048536/40540752-20510dc6-6011-11e8-9a06-95a2cf5587c1.png">



